### PR TITLE
Introducir formateo de código en lo que era el TP0

### DIFF
--- a/.clang-files
+++ b/.clang-files
@@ -1,0 +1,1 @@
+kern/kdebug.c

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,30 @@
+BasedOnStyle: LLVM
+IndentWidth: 8
+UseTab: ForIndentation
+ContinuationIndentWidth: 8
+
+ColumnLimit: 80
+SortIncludes: false
+BreakBeforeBraces: Linux
+
+PointerAlignment: Right
+DerivePointerAlignment: false
+SpaceAfterCStyleCast: true
+SpacesInCStyleCastParentheses: false
+
+BinPackArguments: false
+BinPackParameters: false
+
+IndentCaseLabels: false
+Cpp11BracedListStyle: false
+
+MaxEmptyLinesToKeep: 2
+AlignTrailingComments: true
+SpacesBeforeTrailingComments: 2
+
+KeepEmptyLinesAtTheStartOfBlocks: false
+AllowShortIfStatementsOnASingleLine: false
+AlwaysBreakAfterReturnType: TopLevelDefinitions
+
+PenaltyExcessCharacter: 7
+PenaltyBreakBeforeFirstCallParameter: 50

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+.github/CODEOWNERS	@fiubatps/sisop-adm
+.github/workflows/	@fiubatps/sisop-adm
+.pre-commit-config.yaml	@fiubatps/sisop-adm

--- a/.github/workflows/pre-commit-check.yaml
+++ b/.github/workflows/pre-commit-check.yaml
@@ -1,0 +1,11 @@
+name: pre-commit
+on:
+  pull_request:
+  push:
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,54 @@
+fail_fast: false
+repos:
+  # Este primer pre-commit verifica si todo el código enviado al
+  # repositorio cumple con el formato especificado en .clang-format.
+  # Para correr de manera automática al hacer push, instalar:
+  # https://pre-commit.com y hacer: pre-commit install -t pre-push.
+  - repo: https://github.com/pocc/pre-commit-hooks
+    rev: python
+    hooks:
+      # Por omisión usa la versión de clang-format del sistema, ya
+      # sea la versión 10.0 de Ubuntu 20.04 (focal), o la versión 9
+      # que traen los workers de Github.
+      - id: clang-format
+        args: [-i]
+        # Esta es una lista supuestamente exhaustiva de todos los
+        # archivos que se tocan en el conjunto de entregas de JOS.
+        # Solo esos archivos han sido reformateados con respecto
+        # al fuente original, y solo a esos archivos se les debe
+        # aplicar clang-format (ya sea vía `make format`, o vía
+        # este propio pre-commit).
+        files: |
+          (?x)^($
+             | fs/bc.c
+             | fs/fs.c
+             | fs/serv.c
+             | kern/e1000.c
+             | kern/e1000.h
+             | kern/env.c
+             | kern/init.c
+             | kern/kdebug.c
+             | kern/pmap.c
+             | kern/sched.c
+             | kern/syscall.c
+             | kern/trap.c
+             | lib/file.c
+             | lib/fork.c
+             | lib/ipc.c
+             | lib/libmain.c
+             | lib/spawn.c
+             | net/input.c
+             | net/output.c
+             | user/httpd.c
+             | user/sh.c
+          )$
+
+  # Este otro pre-commit realiza un par de “sanity checks” en el código. Para
+  # mayor pedantería, descomentar end-of-file-fixer, y trailing-whitespace.
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    # - id: end-of-file-fixer
+    # - id: trailing-whitespace
+    - id: check-merge-conflict
+    - id: check-added-large-files

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -197,6 +197,9 @@ grade:
 	  (echo "'make clean' failed.  HINT: Do you have another running instance of JOS?" && exit 1)
 	./grade-lab$(LAB) $(GRADEFLAGS)
 
+format: .clang-files .clang-format
+	xargs -r clang-format -i <$<
+
 git-handin: handin-check
 	@if test -n "`git config remote.handin.url`"; then \
 		echo "Hand in to remote repository using 'git push handin HEAD' ..."; \
@@ -314,5 +317,6 @@ $(OBJDIR)/.deps: $(foreach dir, $(OBJDIRS), $(wildcard $(OBJDIR)/$(dir)/*.d))
 always:
 	@:
 
+.PHONY: format
 .PHONY: all always \
 	handin git-handin tarball tarball-pref clean realclean distclean grade handin-prep handin-check

--- a/kern/init.c
+++ b/kern/init.c
@@ -13,7 +13,7 @@ test_backtrace(int x)
 {
 	cprintf("entering test_backtrace %d\n", x);
 	if (x > 0)
-		test_backtrace(x-1);
+		test_backtrace(x - 1);
 	else
 		mon_backtrace(0, 0, 0);
 	cprintf("leaving test_backtrace %d\n", x);
@@ -55,7 +55,7 @@ const char *panicstr;
  * It prints "panic: mesg", and then enters the kernel monitor.
  */
 void
-_panic(const char *file, int line, const char *fmt,...)
+_panic(const char *file, int line, const char *fmt, ...)
 {
 	va_list ap;
 
@@ -80,7 +80,7 @@ dead:
 
 /* like panic, but don't */
 void
-_warn(const char *file, int line, const char *fmt,...)
+_warn(const char *file, int line, const char *fmt, ...)
 {
 	va_list ap;
 

--- a/kern/kdebug.c
+++ b/kern/kdebug.c
@@ -5,10 +5,10 @@
 
 #include <kern/kdebug.h>
 
-extern const struct Stab __STAB_BEGIN__[];	// Beginning of stabs table
-extern const struct Stab __STAB_END__[];	// End of stabs table
-extern const char __STABSTR_BEGIN__[];		// Beginning of string table
-extern const char __STABSTR_END__[];		// End of string table
+extern const struct Stab __STAB_BEGIN__[];  // Beginning of stabs table
+extern const struct Stab __STAB_END__[];    // End of stabs table
+extern const char __STABSTR_BEGIN__[];      // Beginning of string table
+extern const char __STABSTR_END__[];        // End of string table
 
 
 // stab_binsearch(stabs, region_left, region_right, type, addr)
@@ -48,8 +48,11 @@ extern const char __STABSTR_END__[];		// End of string table
 //	will exit setting left = 118, right = 554.
 //
 static void
-stab_binsearch(const struct Stab *stabs, int *region_left, int *region_right,
-	       int type, uintptr_t addr)
+stab_binsearch(const struct Stab *stabs,
+               int *region_left,
+               int *region_right,
+               int type,
+               uintptr_t addr)
 {
 	int l = *region_left, r = *region_right, any_matches = 0;
 
@@ -59,7 +62,7 @@ stab_binsearch(const struct Stab *stabs, int *region_left, int *region_right,
 		// search for earliest stab with right type
 		while (m >= l && stabs[m].n_type != type)
 			m--;
-		if (m < l) {	// no match in [l, m]
+		if (m < l) {  // no match in [l, m]
 			l = true_m + 1;
 			continue;
 		}
@@ -124,7 +127,7 @@ debuginfo_eip(uintptr_t addr, struct Eipdebuginfo *info)
 		stabstr_end = __STABSTR_END__;
 	} else {
 		// Can't search for user-level addresses yet!
-  	        panic("User address");
+		panic("User address");
 	}
 
 	// String table validity checks
@@ -190,9 +193,8 @@ debuginfo_eip(uintptr_t addr, struct Eipdebuginfo *info)
 	// We can't just use the "lfile" stab because inlined functions
 	// can interpolate code from a different file!
 	// Such included source files use the N_SOL stab type.
-	while (lline >= lfile
-	       && stabs[lline].n_type != N_SOL
-	       && (stabs[lline].n_type != N_SO || !stabs[lline].n_value))
+	while (lline >= lfile && stabs[lline].n_type != N_SOL &&
+	       (stabs[lline].n_type != N_SO || !stabs[lline].n_value))
 		lline--;
 	if (lline >= lfile && stabs[lline].n_strx < stabstr_end - stabstr)
 		info->eip_file = stabstr + stabs[lline].n_strx;


### PR DESCRIPTION
En 774154b ("clang-format for TP1 already") se aplicó clang-format a
todos los archivos involucrados en el TP1 (esto es, que fueran a ser
modificados como parte del TP), y se introdujo el comando `make format`
para correr clang-format sobre esos archivos (listados en .clang-files).

En este commit se baja un nivel, al TP0, el mismo trabajo, con la
siguiente salvedad: además de `make format`, se ofrece una configuración
de pre-commit (https://pre-commit.com) que directamente aplica clang-format
también a todos los archivos involucrados. Además, mediante una Github
Action, se puede saber en todo momento si un commit que fue pusheado (o un
pull request creado) está correctamente formateado.

Es más, como el plugin de pre-commit parece ser resilient a la ausencia de
archivos, si estandarizáramos en pre-commit, no habría que mantener la lista
individual de .clang-files a mano, que cambia TP a TP, y en el pasado ha sido
fuente de merge conflicts. Como contrapartida, exigiríamos la instalación de
un software adicional, que no está en Ubuntu 20.04 (LTS actual).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fisop/jos/7)
<!-- Reviewable:end -->
