### PR TITLE
TP1: remove backtrace implementation part

### DIFF
--- a/TP1.md
+++ b/TP1.md
@@ -1,17 +1,6 @@
 TP1: Memoria virtual en JOS
 ===========================
 
-backtrace_func_names
---------------------
-
-Salida del comando `backtrace`:
-
-```
-K> backtrace
-...
-```
-
-
 boot_alloc_pos
 --------------
 
@@ -28,5 +17,4 @@ map_region_large
 ----------------
 
 ...
-
 

--- a/grade-lab2
+++ b/grade-lab2
@@ -11,33 +11,6 @@ r = Runner(save("jos.out"),
 def test_jos():
     r.run_qemu()
 
-BACKTRACE_RE = r"^ *ebp +f01[0-9a-z]{5} +eip +f0100[0-9a-z]{3} +args +([0-9a-z]+)"
-
-@test(1, parent=test_jos)
-def test_backtrace_count():
-    matches = re.findall(BACKTRACE_RE, r.qemu.output, re.MULTILINE)
-    assert_equal(len(matches), 8)
-
-@test(1, parent=test_jos)
-def test_backtrace_arguments():
-    matches = re.findall(BACKTRACE_RE, r.qemu.output, re.MULTILINE)
-    assert_equal("\n".join(matches[:7]),
-                 "\n".join("%08x" % n for n in [0,0,1,2,3,4,5]))
-
-@test(1, parent=test_jos)
-def test_backtrace_symbols():
-    matches = re.findall(r"kern/init.c:[0-9]+: +([^+]*)\+", r.qemu.output)
-    assert_equal("\n".join(matches[:7]),
-                 "\n".join(["test_backtrace"] * 6 + ["i386_init"]))
-
-@test(1, parent=test_jos)
-def test_backtrace_lines():
-    matches = re.findall(r"([^ ]*init.c:([0-9]+):) +test_backtrace\+", r.qemu.output)
-    assert matches, "No line numbers"
-    if any(int(m[1]) < 5 or int(m[1]) > 50 for m in matches):
-        assert_equal("\n".join(m[0] for m in matches),
-                     "Line numbers between 5 and 50")
-
 @test(1, "Physical page allocator", parent=test_jos)
 def test_check_page_alloc():
     r.match(r"check_page_alloc\(\) succeeded!")

--- a/kern/init.c
+++ b/kern/init.c
@@ -9,19 +9,6 @@
 #include <kern/pmap.h>
 #include <kern/kclock.h>
 
-
-// Test the stack backtrace function (lab 1 only)
-void
-test_backtrace(int x)
-{
-	cprintf("entering test_backtrace %d\n", x);
-	if (x > 0)
-		test_backtrace(x - 1);
-	else
-		mon_backtrace(0, 0, 0);
-	cprintf("leaving test_backtrace %d\n", x);
-}
-
 void
 i386_init(void)
 {
@@ -37,9 +24,6 @@ i386_init(void)
 	cons_init();
 
 	cprintf("6828 decimal is %o octal!\n", 6828);
-
-	// Test the stack backtrace function (lab 1 only)
-	test_backtrace(5);
 
 	// Lab 2 memory management initialization functions
 	mem_init();


### PR DESCRIPTION
This includes:
- TP1.md: space for answers
- kern/init.c: testing backtrace function
- grade-lab2: tests verifying correct output of `mon_backtrace` command

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fisop/jos/8)
<!-- Reviewable:end -->
